### PR TITLE
chart: remove label selectors

### DIFF
--- a/charts/brigade-cron-event-source/templates/_helpers.tpl
+++ b/charts/brigade-cron-event-source/templates/_helpers.tpl
@@ -35,17 +35,10 @@ Common labels
 */}}
 {{- define "brigade-cron-event-source.labels" -}}
 helm.sh/chart: {{ include "brigade-cron-event-source.chart" . }}
-{{ include "brigade-cron-event-source.selectorLabels" . }}
+app.kubernetes.io/name: {{ include "brigade-cron-event-source.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "brigade-cron-event-source.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "brigade-cron-event-source.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/brigade-cron-event-source/templates/cronjob.yaml
+++ b/charts/brigade-cron-event-source/templates/cronjob.yaml
@@ -1,6 +1,5 @@
 {{ $fullname := include "brigade-cron-event-source.fullname" . }}
 {{ $labels := include "brigade-cron-event-source.labels" . }}
-{{ $selectorLabels := include "brigade-cron-event-source.selectorLabels" . }}
 {{- range $.Values.cronEvents }}
 apiVersion: batch/v1
 kind: CronJob
@@ -25,7 +24,7 @@ spec:
           {{- end }}        
           labels:
             cronjob: {{ $fullname }}-{{ .nameSuffix }}
-            {{- $selectorLabels | nindent 12 }}
+            {{- $labels | nindent 12 }}
         spec:
           securityContext:
             {{- toYaml $.Values.podSecurityContext | nindent 12 }}


### PR DESCRIPTION
I'm not aware of label selectors being relevant to cron jobs. At least I don't see any mention of it in the documentation and we certainly weren't selecting anything on the basis of these labels, so this PR removes that helper and folds those labels into the other label helper.