### PR TITLE
chart: shorten helper names

### DIFF
--- a/charts/brigade-cron-event-source/templates/_helpers.tpl
+++ b/charts/brigade-cron-event-source/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "brigade-cron-event-source.name" -}}
+{{- define "event-source.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 58 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 58 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "brigade-cron-event-source.fullname" -}}
+{{- define "event-source.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 58 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "brigade-cron-event-source.chart" -}}
+{{- define "event-source.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 58 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "brigade-cron-event-source.labels" -}}
-helm.sh/chart: {{ include "brigade-cron-event-source.chart" . }}
-app.kubernetes.io/name: {{ include "brigade-cron-event-source.name" . }}
+{{- define "event-source.labels" -}}
+helm.sh/chart: {{ include "event-source.chart" . }}
+app.kubernetes.io/name: {{ include "event-source.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/charts/brigade-cron-event-source/templates/configmap.yaml
+++ b/charts/brigade-cron-event-source/templates/configmap.yaml
@@ -1,5 +1,5 @@
-{{ $fullname := include "brigade-cron-event-source.fullname" . }}
-{{ $labels := include "brigade-cron-event-source.labels" . }}
+{{ $fullname := include "event-source.fullname" . }}
+{{ $labels := include "event-source.labels" . }}
 {{- range $.Values.cronEvents }}
 kind: ConfigMap
 apiVersion: v1

--- a/charts/brigade-cron-event-source/templates/cronjob.yaml
+++ b/charts/brigade-cron-event-source/templates/cronjob.yaml
@@ -1,5 +1,5 @@
-{{ $fullname := include "brigade-cron-event-source.fullname" . }}
-{{ $labels := include "brigade-cron-event-source.labels" . }}
+{{ $fullname := include "event-source.fullname" . }}
+{{ $labels := include "event-source.labels" . }}
 {{- range $.Values.cronEvents }}
 apiVersion: batch/v1
 kind: CronJob


### PR DESCRIPTION
This isn't super critical, but shortening the helper names makes the rest of the templates easier to read.

This builds on #20, so this should be rebased after that is merged.