### PR TITLE
chart: remove resource options

### DIFF
--- a/charts/brigade-cron-event-source/templates/cronjobs.yaml
+++ b/charts/brigade-cron-event-source/templates/cronjobs.yaml
@@ -35,10 +35,6 @@ spec:
               {{- toYaml $.Values.securityContext | nindent 14 }}
             image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
             imagePullPolicy: {{ default "IfNotPresent" $.Values.image.pullPolicy }}
-            {{- with $.Values.resources }}
-            resources: 
-              {{- toYaml . | nindent 14 }}
-            {{- end }}
             env:
             - name: API_ADDRESS
               value: {{ $.Values.brigade.apiAddress }}

--- a/charts/brigade-cron-event-source/values.yaml
+++ b/charts/brigade-cron-event-source/values.yaml
@@ -91,18 +91,6 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
-resources: 
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
-
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
This Go program is so small, short-lived, and will consume so little in terms of resources, that it doesn't make a lot of sense to leave resource requests customizable. Removing this option keeps things a bit simpler.