### PR TITLE
chart: add some boilerplate to the top of the values.yaml

### DIFF
--- a/charts/brigade-cron-event-source/values.yaml
+++ b/charts/brigade-cron-event-source/values.yaml
@@ -1,3 +1,7 @@
+## Default values for brigade-cron-event-source
+## This is a YAML-formatted file.
+## Declare variables to be passed into your templates.
+
 #
 # cron event sources to be created
 #


### PR DESCRIPTION
This is just a bit of boilerplate that exists in the charts of all sibling repositories. Just trying to ensure as much consistency as possible with established conventions.