### PR TITLE
chart: use conventions established in sibling repos for image section of values.yaml

### DIFF
--- a/charts/brigade-cron-event-source/values.yaml
+++ b/charts/brigade-cron-event-source/values.yaml
@@ -37,10 +37,11 @@ brigadeApi:
   tokenSecretName: "brigade-api-server-token"
 
 image:
-  repository: "jorgearteiro/brigade-cron-eventsource"
-  pullPolicy:  "IfNotPresent" #"Always"
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.1.0"
+  repository: brigadecore/brigade-cron-event-source
+  ## tag should only be specified if you want to override Chart.appVersion
+  ## The default tag is the value of .Chart.AppVersion
+  # tag:
+  pullPolicy: IfNotPresent
 
 successfulJobsHistoryLimit: 10
 failedJobsHistoryLimit: 10


### PR DESCRIPTION
For the sake of consistency, this PR updates the `image:` section of `values.yaml` to match _de facto_ conventions established by sibling repos.
