### PR TITLE
chart: use conventions established in sibling repos for brigade section of values.yaml

### DIFF
--- a/charts/brigade-cron-event-source/templates/cronjobs.yaml
+++ b/charts/brigade-cron-event-source/templates/cronjobs.yaml
@@ -40,19 +40,19 @@ spec:
               {{- toYaml . | nindent 14 }}
             {{- end }}  
             env:
+            - name: API_ADDRESS
+              value: {{ $.Values.brigade.apiAddress }}
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $fullname }}
+                  key: brigadeAPIToken
+            - name: API_IGNORE_CERT_WARNINGS
+              value: {{ quote $.Values.brigade.apiIgnoreCertWarnings }}
             - name: BRIGADE_SOURCE
               value: "{{ .source }}"
             - name: BRIGADE_TYPE
               value: "{{ .type }}"
-            - name: API_ADDRESS
-              value: "{{ $.Values.brigadeApi.address }}"
-            - name: API_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  key: apitoken
-                  name: {{ $.Values.brigadeApi.tokenSecretName }}     
-            - name: API_IGNORE_CERT_WARNINGS
-              value: "{{ $.Values.brigadeApi.ignoreCertWarnings }}"  
             volumeMounts:
             - name: cronjob-config
               mountPath: "/cronjob-config"

--- a/charts/brigade-cron-event-source/templates/secret.yaml
+++ b/charts/brigade-cron-event-source/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "event-source.fullname" . }}
+  labels:
+    {{- include "event-source.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.brigade.apiToken }}
+  brigadeAPIToken: {{ .Values.brigade.apiToken }}
+  {{- else }}
+    {{ fail "Value MUST be specified for brigade.apiToken" }}
+  {{- end }}

--- a/charts/brigade-cron-event-source/values.yaml
+++ b/charts/brigade-cron-event-source/values.yaml
@@ -32,13 +32,14 @@ cronEvents:
     labels: {}
     payload: {}    
 
-#
-# brigade-cron-event-sources values
-#
-brigadeApi:
-  address: "https://brigade-apiserver.brigade.svc.cluster.local"
-  ignoreCertWarnings: "true"
-  tokenSecretName: "brigade-api-server-token"
+brigade:
+  ## Address of your Brigade 2 API server, including leading protocol (http://
+  ## or https://)
+  apiAddress: https://brigade-apiserver.brigade.svc.cluster.local
+  ## API token belonging to a Brigade 2 service account
+  apiToken:
+  ## Whether to ignore cert warning from the API server
+  apiIgnoreCertWarnings: true
 
 image:
   repository: brigadecore/brigade-cron-event-source


### PR DESCRIPTION
For the sake of consistency, this PR updates the `brigade:` section of `values.yaml` and associated templates to match de facto conventions established by sibling repos.