### PR TITLE
refactor for simplicity and efficiency

### DIFF
--- a/charts/brigade-cron-event-source/templates/configmaps.yaml
+++ b/charts/brigade-cron-event-source/templates/configmaps.yaml
@@ -1,24 +1,15 @@
 {{ $fullname := include "event-source.fullname" . }}
 {{ $labels := include "event-source.labels" . }}
-{{- range $.Values.cronEvents }}
+{{- range $.Values.events }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: {{ $fullname }}-{{ .nameSuffix }}
+  name: {{ $fullname }}-{{ .name }}
   labels:
     {{- $labels | nindent 4 }}
+    cronjob: {{ .name }}
 data:
-  {{- with .qualifiers }}
-  qualifiers: |
-    {{- toYaml . | nindent 4 }}    
-  {{- end }}
-  {{- with .labels }}
-  labels: |
-    {{- toYaml . | nindent 4 }}    
-  {{- end }}
-  {{- with .payload }}
-  payload: |
-    {{- toYaml . | nindent 4 }}    
-  {{- end }}
+  event.yaml: |
+    {{- toYaml .brigadeEvent | nindent 4 }}
 ---  
-{{- end}}  
+{{- end}}

--- a/charts/brigade-cron-event-source/templates/cronjobs.yaml
+++ b/charts/brigade-cron-event-source/templates/cronjobs.yaml
@@ -1,15 +1,15 @@
 {{ $fullname := include "event-source.fullname" . }}
 {{ $labels := include "event-source.labels" . }}
-{{- range $.Values.cronEvents }}
+{{- range $.Values.events }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ $fullname }}-{{ .nameSuffix }}
+  name: {{ $fullname }}-{{ .name }}
   labels:
-    cronjob: {{ $fullname }}-{{ .nameSuffix }}
+    cronjob: {{ .name }}
     {{- $labels | nindent 4 }}
 spec:
-  schedule: "{{ default "@hourly" .schedule }}"
+  schedule: {{ quote .schedule }}
   successfulJobsHistoryLimit: {{ default 10 $.Values.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ default 10 $.Values.failedJobsHistoryLimit }}
   concurrencyPolicy: "Forbid"
@@ -17,28 +17,28 @@ spec:
     spec:
       template:
         metadata:
-          name: {{ $fullname }}-{{ .nameSuffix }}
+          name: {{ $fullname }}-{{ .name }}
           {{- with $.Values.podAnnotations }}
           annotations:
             {{- toYaml . | nindent 12 }}
           {{- end }}        
           labels:
-            cronjob: {{ $fullname }}-{{ .nameSuffix }}
+            cronjob: {{ .name }}
             {{- $labels | nindent 12 }}
         spec:
           securityContext:
             {{- toYaml $.Values.podSecurityContext | nindent 12 }}
           restartPolicy: OnFailure
           containers:
-          - name: {{ $.Chart.Name }}-job
+          - name: brigade-cron-event-source
             securityContext:
               {{- toYaml $.Values.securityContext | nindent 14 }}
             image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
             imagePullPolicy: {{ default "IfNotPresent" $.Values.image.pullPolicy }}
-            {{- with $.Values.resources }}             
+            {{- with $.Values.resources }}
             resources: 
               {{- toYaml . | nindent 14 }}
-            {{- end }}  
+            {{- end }}
             env:
             - name: API_ADDRESS
               value: {{ $.Values.brigade.apiAddress }}
@@ -49,13 +49,9 @@ spec:
                   key: brigadeAPIToken
             - name: API_IGNORE_CERT_WARNINGS
               value: {{ quote $.Values.brigade.apiIgnoreCertWarnings }}
-            - name: BRIGADE_SOURCE
-              value: "{{ .source }}"
-            - name: BRIGADE_TYPE
-              value: "{{ .type }}"
             volumeMounts:
-            - name: cronjob-config
-              mountPath: "/cronjob-config"
+            - name: config
+              mountPath: "/app/config"
               readOnly: true  
           {{- with $.Values.nodeSelector }}
           nodeSelector:
@@ -70,21 +66,8 @@ spec:
             {{- toYaml . | nindent 8 }}
           {{- end }}
           volumes:
-            - name: cronjob-config
-              configMap:
-                name: {{ $fullname }}-{{ .nameSuffix }}
-                items:
-                {{- with .qualifiers }}                
-                - key: "qualifiers"
-                  path: "qualifiers"
-                {{- end }}
-                {{- with .labels }}                
-                - key: "labels"  
-                  path: "labels"
-                {{- end }}
-                {{- with .payload }}                
-                - key: "payload"  
-                  path: "payload"
-                {{- end }}
+          - name: config
+            configMap:
+              name: {{ $fullname }}-{{ .name }}
 --- 
 {{- end }}

--- a/charts/brigade-cron-event-source/values.yaml
+++ b/charts/brigade-cron-event-source/values.yaml
@@ -2,35 +2,58 @@
 ## This is a YAML-formatted file.
 ## Declare variables to be passed into your templates.
 
-#
-# cron event sources to be created
-#
-# https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule
-# schedule: "*/5 * * * *" # Every 5 minutes
-# schedule: "*/1 * * * *" # Every 1 minutes
-# schedule: "@hourly"
-# schedule: "@daily"
-# schedule: "@weekly"
-# schedule: "@monthly"
-# schedule: "@yearly"
-cronEvents:
-  - nameSuffix: "job01" #maximum 5 chars
-    source: "cronsource"
-    type: "cron"
-    schedule: "*/1 * * * *"
-    qualifiers: 
-      customer: "cron event"
-    labels: 
-      costCenter: "finance"
-    payload: 
-      data: "test cron event source"
-  - nameSuffix: "job02" #maximum 5 chars
-    source: "cronsource"
-    type: "cron"
-    schedule: "*/5 * * * *"
-    qualifiers: {}
-    labels: {}
-    payload: {}    
+## Events to be emitted, each on the indicated schedule
+events: []
+# ## Example:
+# ## 
+# ## Note that this example works with the hello-world example project found at
+# ## https://github.com/brigadecore/brigade/blob/main/examples/01-hello-world/project.yaml
+# ##
+# ## This example emits events that the hello-world example project already
+# ## subscribes to -- namely events that are ordinarily created using the Brigade
+# ## CLI. This demonstrates the flexibility of this event source. It can create
+# ## any type of event you like, as long as it is granted permissions to do so.
+# ##
+# ## For reference, these are the commands for creating a service account for
+# ## this event source, with proper permissions for this example:
+# ##
+# ##   $ brig service-account create \
+# ##       --id brigade-cron-event-source \
+# ##       --description brigade-cron-event-source
+# ##
+# ##   $ brig project role grant PROJECT_USER \
+# ##       --project hello-world \
+# ##       --service-account brigade-cron-event-source
+# - name: hello-world
+#   ## https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule
+#   ##
+#   ## Examples:
+#   ##
+#   ##   schedule: "*/5 * * * *" # Every 5 minutes
+#   ##   schedule: "*/1 * * * *" # Every 1 minutes
+#   ##   schedule: "@hourly"
+#   ##   schedule: "@daily"
+#   ##   schedule: "@weekly"
+#   ##   schedule: "@monthly"
+#   ##   schedule: "@yearly"
+#   schedule: "*/10 * * * *"
+#   successfulJobsHistoryLimit: 10
+#   failedJobsHistoryLimit: 10
+#   ## For Brigade event schema, see
+#   ## https://schemas.brigade.sh/schemas-v2/event.json
+#   brigadeEvent:
+#     apiVersion: brigade.sh/v2
+#     kind: Event
+#     ## Prevent "over-subscriptions" by targeting a specific Brigade project
+#     projectID: hello-world
+#     ## Use any event source you like as long as your Brigade service account
+#     ## has corresponding permissions 
+#     source: brigade.sh/cli
+#     ## Use any type you like
+#     type: exec
+#     qualifiers: {}
+#     labels: {}
+#     payload: ""
 
 brigade:
   ## Address of your Brigade 2 API server, including leading protocol (http://

--- a/config.go
+++ b/config.go
@@ -1,12 +1,12 @@
 package main
 
-// nolint: lll
 import (
-	"encoding/json"
 	"io/ioutil"
 
 	"github.com/brigadecore/brigade-foundations/os"
+	"github.com/brigadecore/brigade/sdk/v2/core"
 	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/ghodss/yaml"
 )
 
 // apiClientConfig populates the Brigade SDK's APIClientOptions from
@@ -26,48 +26,12 @@ func apiClientConfig() (string, string, restmachinery.APIClientOptions, error) {
 	return address, token, opts, err
 }
 
-func eventConfig() (string, string, error) {
-	brigadeSource, err := os.GetRequiredEnvVar("BRIGADE_SOURCE")
+func event() (core.Event, error) {
+	event := core.Event{}
+	eventBytes, err := ioutil.ReadFile("/app/config/event.yaml")
 	if err != nil {
-		return brigadeSource, "", err
+		return event, err
 	}
-	brigadeType, err := os.GetRequiredEnvVar("BRIGADE_TYPE")
-	if err != nil {
-		return brigadeSource, brigadeType, err
-	}
-	return brigadeSource, brigadeType, err
-}
-
-func qualifiersConfig() (map[string]string, error) {
-	qualifiersBytes, err := ioutil.ReadFile("/cronjob-config/qualifiers")
-	if err != nil {
-		return map[string]string{}, err
-	}
-	qualifiersPlainText := map[string]string{}
-	if err :=
-		json.Unmarshal(qualifiersBytes, &qualifiersPlainText); err != nil {
-		return map[string]string{}, err
-	}
-	return qualifiersPlainText, nil
-}
-
-func labelsConfig() (map[string]string, error) {
-	labelsBytes, err := ioutil.ReadFile("/cronjob-config/labels")
-	if err != nil {
-		return map[string]string{}, err
-	}
-	labelsPlainText := map[string]string{}
-	if err :=
-		json.Unmarshal(labelsBytes, &labelsPlainText); err != nil {
-		return map[string]string{}, err
-	}
-	return labelsPlainText, nil
-}
-
-func payloadConfig() (string, error) {
-	payloadBytes, err := ioutil.ReadFile("/cronjob-config/payload")
-	if err != nil {
-		return "", err
-	}
-	return string(payloadBytes), nil
+	err = yaml.Unmarshal(eventBytes, &event)
+	return event, err
 }

--- a/config.go
+++ b/config.go
@@ -4,8 +4,8 @@ import (
 	"io/ioutil"
 
 	"github.com/brigadecore/brigade-foundations/os"
-	"github.com/brigadecore/brigade/sdk/v2/core"
-	"github.com/brigadecore/brigade/sdk/v2/restmachinery"
+	"github.com/brigadecore/brigade/sdk/v3"
+	"github.com/brigadecore/brigade/sdk/v3/restmachinery"
 	"github.com/ghodss/yaml"
 )
 
@@ -26,8 +26,8 @@ func apiClientConfig() (string, string, restmachinery.APIClientOptions, error) {
 	return address, token, opts, err
 }
 
-func event() (core.Event, error) {
-	event := core.Event{}
+func event() (sdk.Event, error) {
+	event := sdk.Event{}
 	eventBytes, err := ioutil.ReadFile("/app/config/event.yaml")
 	if err != nil {
 		return event, err

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.17
 require (
 	github.com/brigadecore/brigade-foundations v0.3.0
 	github.com/brigadecore/brigade/sdk/v2 v2.2.0
+	github.com/ghodss/yaml v1.0.0
 )
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/brigadecore/brigade-foundations v0.3.0
-	github.com/brigadecore/brigade/sdk/v2 v2.2.0
+	github.com/brigadecore/brigade/sdk/v3 v3.0.0
 	github.com/ghodss/yaml v1.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/brigadecore/brigade-foundations v0.3.0 h1:galsMzxSprURAEc2pxsmYJandiW4D+Npchx6ZiBIHkY=
 github.com/brigadecore/brigade-foundations v0.3.0/go.mod h1:edMgSJCUgfHN1RNGiiVOTRW4X4VykBLgssgWHPZK7Sg=
-github.com/brigadecore/brigade/sdk/v2 v2.2.0 h1:r9j7mCPUoBqiaOllKzdSl1GZp8Bx7SCJixgp3BFEMwg=
-github.com/brigadecore/brigade/sdk/v2 v2.2.0/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/U6bUAUtSLkgJcbOHIY=
+github.com/brigadecore/brigade/sdk/v3 v3.0.0 h1:jCjKQuoDYK8J+P2Zpuc/IQK/GKx0M678AbD0GgxOvcM=
+github.com/brigadecore/brigade/sdk/v3 v3.0.0/go.mod h1:Ow91x3wvUtkyMsV6hwbPtVZevrcHqoH0Pjh0OID4Sh0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/brigadecore/brigade/sdk/v2 v2.2.0/go.mod h1:rB3y/pIheORX5AHbxaSAw5Xr/
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
@@ -20,6 +22,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/brigadecore/brigade/sdk/v2/core"
+	"github.com/brigadecore/brigade/sdk/v3"
 )
 
 func main() {
@@ -13,15 +13,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	client := core.NewEventsClient(address, token, &opts)
+	client := sdk.NewEventsClient(address, token, &opts)
 
 	event, err := event()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	var eventList core.EventList
-	if eventList, err = client.Create(context.Background(), event); err != nil {
+	var eventList sdk.EventList
+	if eventList, err =
+		client.Create(context.Background(), event, nil); err != nil {
 		log.Fatalf("error creating event: %s", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,16 +1,13 @@
 package main
 
 import (
+	"context"
 	"log"
 
-	"github.com/brigadecore/brigade-foundations/signals"
 	"github.com/brigadecore/brigade/sdk/v2/core"
 )
 
 func main() {
-
-	ctx := signals.Context()
-
 	address, token, opts, err := apiClientConfig()
 	if err != nil {
 		log.Fatal(err)
@@ -18,31 +15,18 @@ func main() {
 
 	client := core.NewEventsClient(address, token, &opts)
 
-	brigadeSource, brigadeType, _ := eventConfig()
+	event, err := event()
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	qualifiers, _ := qualifiersConfig()
-
-	labels, _ := labelsConfig()
-
-	payload, _ := payloadConfig()
-
-	brigadeEvent := core.Event{
-		Source:     brigadeSource,
-		Type:       brigadeType,
-		Qualifiers: qualifiers,
-		Labels:     labels,
-		Payload:    payload,
+	var eventList core.EventList
+	if eventList, err = client.Create(context.Background(), event); err != nil {
+		log.Fatalf("error creating event: %s", err)
 	}
 
-	eventList, err := client.Create(ctx, brigadeEvent)
-
-	if err != nil {
-		log.Fatal(err)
-	} else {
-		log.Println(eventList)
+	log.Println("Created events: ")
+	for _, event = range eventList.Items {
+		log.Println(event.ID)
 	}
-
 }


### PR DESCRIPTION
This PR reorganizes the `values.yaml` data that is handed off to the Go code via `ConfigMap` so that the entire event ends up in a file that the program can simply parse and use.

This eliminates the existing complexity and inefficiency inherent in extracting individual fields from the event and passing them in through various mechanisms (env vars, config map, etc.)

This new strategy is also more future-proof. If new fields are added to Brigade events in the future, they can be used here without any modification to the code.

Note to reviewers: This PR is easiest to understand if you start from the `values.yaml` file and work backwards from there.