### PR TITLE
remove imagePullSecrets from values.yaml

### DIFF
--- a/charts/brigade-cron-event-source/values.yaml
+++ b/charts/brigade-cron-event-source/values.yaml
@@ -70,8 +70,9 @@ events: []
 #     labels: {}
 #     payload: ""
 
-imagePullSecrets: []
+
 nameOverride: ""
+
 fullnameOverride: ""
 
 podAnnotations: {}


### PR DESCRIPTION
This value isn't used in any of the templates.

Rather than make the templates use this, I'm electing to remove it from `values.yaml`, for now at least.