### PR TITLE
update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
-# Global Owners: These are brigadecore org maintainers + maintainers of this repo
-* @brigadecore/maintainers @brigadecore/cron-event-source-maintainers
+# Global Owners: These are brigadecore org maintainers + specific outside collaborators
+* @brigadecore/maintainers @jorgearteiro


### PR DESCRIPTION
The `cron-event-source-maintainers` team no longer exists.

It had only one member.

I've been auditing membership in the org in order to preserve secrets if we soon start to add some private repos, so this individual was downgraded to an "outside collaborator." He retains his privileged access to this one repo, but the `cron-event-source-maintainers` team no longer has any members.

Since the `cron-event-source-maintainers` team no longer exists, this PR explicitly calls out the one outside collaborator who is authorized to review PRs to this repo.